### PR TITLE
Fix 502 Bad Gateway errors by increasing nginx buffer sizes

### DIFF
--- a/nginx/prod/conf.d/kirstensiebach.conf
+++ b/nginx/prod/conf.d/kirstensiebach.conf
@@ -18,6 +18,11 @@ server {
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
+
+        # Increase buffer sizes to handle large headers
+        fastcgi_buffer_size 32k;
+        fastcgi_buffers 8 16k;
+        fastcgi_busy_buffers_size 32k;
     }
 
     location /storage {


### PR DESCRIPTION
## Summary
- Fixes 502 Bad Gateway errors occurring on admin routes
- Resolves "upstream sent too big header" nginx errors
- Increases FastCGI buffer sizes to handle large response headers from PHP-FPM

## Problem
Production logs showed repeated 502 errors with this nginx error:
```
upstream sent too big header while reading response header from upstream
```

This was happening on routes like:
- `/admin/pages/research-pages`
- `/admin/research`

The issue occurs when Laravel/Filament sends response headers that exceed nginx's default buffer sizes (typically 4k-8k). This commonly happens with:
- Large session data stored in cookies
- Multiple authentication cookies
- Filament admin panel session data

## Solution
Added three FastCGI buffer configuration directives to the nginx PHP location block:
- `fastcgi_buffer_size 32k` - Initial buffer for response headers
- `fastcgi_buffers 8 16k` - 8 buffers of 16k each for response body
- `fastcgi_busy_buffers_size 32k` - Maximum size for busy buffers

## Deployment Steps
1. Merge this PR
2. Deploy to production
3. Restart nginx container: `docker restart webserver`
4. Test affected admin routes

## Test Plan
- [ ] Deploy to production
- [ ] Verify `/admin/research` loads without 502 errors
- [ ] Verify `/admin/pages/research-pages` loads without 502 errors
- [ ] Check nginx error logs for absence of "upstream sent too big header" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)