### PR TITLE
Fix profile picture upload rejecting valid JPG files

### DIFF
--- a/app/Filament/Resources/TeamMembers/Schemas/TeamMemberForm.php
+++ b/app/Filament/Resources/TeamMembers/Schemas/TeamMemberForm.php
@@ -31,6 +31,7 @@ class TeamMemberForm
                     ->rows(5),
                 FileUpload::make('profile_picture')
                     ->image()
+                    ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/gif', 'image/webp', 'image/jpg', 'image/pjpeg'])
                     ->disk('public')
                     ->directory('team')
                     ->label('Profile Picture')


### PR DESCRIPTION
## Summary
- Adds explicit `acceptedFileTypes()` to the profile picture FileUpload to allow non-standard MIME types
- Fixes issue where valid JPG files were rejected with "must be a file of type: image/*" error

## Problem
Some JPG files (especially from cameras or certain image editing software) have non-standard MIME types like `image/pjpeg` (progressive JPEG) or `image/jpg` instead of the standard `image/jpeg`. The `->image()` method alone doesn't accept these variants.

## Solution
Added explicit accepted file types:
- `image/jpeg` - standard JPEG
- `image/png`, `image/gif`, `image/webp` - other common formats  
- `image/jpg` - non-standard but sometimes used
- `image/pjpeg` - progressive JPEG from older software/cameras

## Test plan
- [ ] Upload a JPG file that was previously failing
- [ ] Verify standard image formats still work (PNG, GIF, WebP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)